### PR TITLE
Remove `bottle :unneeded`

### DIFF
--- a/formula_templates/poly-migrator_template.rb
+++ b/formula_templates/poly-migrator_template.rb
@@ -5,8 +5,6 @@ class PolyMigratorVERSION_NAME < Formula
   sha256 "SHASUM"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   uses_from_macos "ruby" => :build
 
   def install

--- a/formula_templates/poly_template.rb
+++ b/formula_templates/poly_template.rb
@@ -5,8 +5,6 @@ class PolyVERSION_NAME < Formula
   sha256 "SHASUM"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   uses_from_macos "ruby" => :build
 
   def install


### PR DESCRIPTION
`bottle :unneeded` is removed from homebrew core since [#11239](https://github.com/Homebrew/brew/pull/11239). Keeping it in the Formula results in printing `Warning: Calling bottle :unneeded is deprecated! There is no replacement.` message. This PR removes the unnecessary line to avoid that.