### PR TITLE
Removing :unneeded bottle config

### DIFF
--- a/Formula/poly-migrator.rb
+++ b/Formula/poly-migrator.rb
@@ -5,8 +5,6 @@ class PolyMigrator < Formula
   sha256 "f2e46261e3fc0e95b1f5c3fa9cca8113c500d1636ade270e5fce6610a60dff25"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly-migrator@0.1.0-alpha3.rb
+++ b/Formula/poly-migrator@0.1.0-alpha3.rb
@@ -5,8 +5,6 @@ class PolyMigratorAT010Alpha3 < Formula
   sha256 "1eb6bb59350944e3dd0c1d22cf43f32170aac8a2532919b22be36d71eb028d0a"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly-migrator@0.1.0-alpha4.rb
+++ b/Formula/poly-migrator@0.1.0-alpha4.rb
@@ -5,8 +5,6 @@ class PolyMigratorAT010Alpha4 < Formula
   sha256 "65df911aa09c637a6b5fa7cb94aab6b4301290714c0055aeae7f84fd5bcf7657"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly-migrator@0.1.0-alpha5.rb
+++ b/Formula/poly-migrator@0.1.0-alpha5.rb
@@ -5,8 +5,6 @@ class PolyMigratorAT010Alpha5 < Formula
   sha256 "b43cba621c8f0a5e21b1a71dacacaa96a3700bf6060f7caaa8dbf67dcf5f44d1"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly-migrator@0.1.0-alpha6.rb
+++ b/Formula/poly-migrator@0.1.0-alpha6.rb
@@ -5,8 +5,6 @@ class PolyMigratorAT010Alpha6 < Formula
   sha256 "3d86a5b937e633c5dbd0c3caef9e72e4f78ca869f22e9b621f7203113b399721"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly-migrator@0.1.0-alpha7.rb
+++ b/Formula/poly-migrator@0.1.0-alpha7.rb
@@ -5,8 +5,6 @@ class PolyMigratorAT010Alpha7 < Formula
   sha256 "d820ce787b5dec6f0fe8e7ebaa458226e9c54b357fe4dfed3d53a8b615e5dbc3"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly-migrator@0.1.0-alpha8.rb
+++ b/Formula/poly-migrator@0.1.0-alpha8.rb
@@ -5,8 +5,6 @@ class PolyMigratorAT010Alpha8 < Formula
   sha256 "2566c2a1e19abf6bdb0dc278c97e1037d3b2af29b788c5664945f7613cc5e317"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly-migrator@0.1.0-alpha9.rb
+++ b/Formula/poly-migrator@0.1.0-alpha9.rb
@@ -5,8 +5,6 @@ class PolyMigratorAT010Alpha9 < Formula
   sha256 "f2e46261e3fc0e95b1f5c3fa9cca8113c500d1636ade270e5fce6610a60dff25"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly.rb
+++ b/Formula/poly.rb
@@ -5,8 +5,6 @@ class Poly < Formula
   sha256 "7fcb172f9f3f691662097f3f34ae87b00103a5063ef2941e035351b7cff99b08"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   uses_from_macos "ruby" => :build
 
   def install

--- a/Formula/poly@0.1.0-alpha2.rb
+++ b/Formula/poly@0.1.0-alpha2.rb
@@ -5,8 +5,6 @@ class PolyAT010Alpha2 < Formula
   sha256 "7a96b214652dbe91bb2d7061c736846bb280650f4c792b6fbe0d044c2fbcfb8a"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.1.0-alpha3.rb
+++ b/Formula/poly@0.1.0-alpha3.rb
@@ -5,8 +5,6 @@ class PolyAT010Alpha3 < Formula
   sha256 "186c94f58e96cdb6afe29c9837e21715e2076abaea4737259d7559be45ea264c"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.1.0-alpha4.rb
+++ b/Formula/poly@0.1.0-alpha4.rb
@@ -5,8 +5,6 @@ class PolyAT010Alpha4 < Formula
   sha256 "b921f956297121541a273dc51d1629431755b100933c4af6e8dd0ef6f1518689"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.1.0-alpha5.rb
+++ b/Formula/poly@0.1.0-alpha5.rb
@@ -5,8 +5,6 @@ class PolyAT010Alpha5 < Formula
   sha256 "e4c40b33b40ea3c8d691bf3e62e6175a16e0fc327353052f55337fe80d7edfa3"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.1.0-alpha6.rb
+++ b/Formula/poly@0.1.0-alpha6.rb
@@ -5,8 +5,6 @@ class PolyAT010Alpha6 < Formula
   sha256 "f6f92884711f61aa670fc16f665d390fa69f61bea69a20c25cc8c28b6f49b4aa"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.1.0-alpha7.rb
+++ b/Formula/poly@0.1.0-alpha7.rb
@@ -5,8 +5,6 @@ class PolyAT010Alpha7 < Formula
   sha256 "10ecc3fef1edbc15ee33219c663bcf55cc40532ef4a0f3479377812602a4460e"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.1.0-alpha8.rb
+++ b/Formula/poly@0.1.0-alpha8.rb
@@ -5,8 +5,6 @@ class PolyAT010Alpha8 < Formula
   sha256 "6242cf4b4aa5e3a46f38e98a5a22b07f4fad44a1fa90d292230d7abf9a032f16"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.1.0-alpha9.rb
+++ b/Formula/poly@0.1.0-alpha9.rb
@@ -5,8 +5,6 @@ class PolyAT010Alpha9 < Formula
   sha256 "2f809c583b0bf6421ee3837c97ec329b396d6c5ba4e287cfb8f3cf7ec8ec0baf"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.2.0-alpha10.rb
+++ b/Formula/poly@0.2.0-alpha10.rb
@@ -5,8 +5,6 @@ class PolyAT020Alpha10 < Formula
   sha256 "34cbb5e38cc86dd2e441a4074b2459884e35ef8c43b52bbcdcc66b873279a69f"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.2.0-alpha11.rb
+++ b/Formula/poly@0.2.0-alpha11.rb
@@ -5,8 +5,6 @@ class PolyAT020Alpha11 < Formula
   sha256 "7e574affb19997e323f8738f4276309522eda4a5ed3ccba4b1758045e84ab64e"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.2.12-alpha.rb
+++ b/Formula/poly@0.2.12-alpha.rb
@@ -5,8 +5,6 @@ class PolyAT0212Alpha < Formula
   sha256 "ff42d7e3cc1625d34b69f6e315c45e27265c1cb78d5ce102ebb0ec11ef943795"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   depends_on "openjdk"
 
   uses_from_macos "ruby" => :build

--- a/Formula/poly@0.2.13-alpha.rb
+++ b/Formula/poly@0.2.13-alpha.rb
@@ -5,8 +5,6 @@ class PolyAT0213Alpha < Formula
   sha256 "7fcb172f9f3f691662097f3f34ae87b00103a5063ef2941e035351b7cff99b08"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   uses_from_macos "ruby" => :build
 
   def install


### PR DESCRIPTION
Trying to fix the MacOs installation problem.
`Error: Invalid formula: <path>: Calling bottle :unneeded is disabled! There is no replacement.`

I'm not sure if this is the best way, but I felt compelled to try to help.