### PR TITLE
Remove `bottle :unneeded` from v0.2.14-alpha formula

### DIFF
--- a/Formula/poly@0.2.14-alpha.rb
+++ b/Formula/poly@0.2.14-alpha.rb
@@ -5,8 +5,6 @@ class PolyAT0214Alpha < Formula
   sha256 "027cddf1f818027c1ec28d233167a689fec7c0ba49daaf84198841642fb6c9bf"
   license "EPL-1.0"
 
-  bottle :unneeded
-
   uses_from_macos "ruby" => :build
 
   def install


### PR DESCRIPTION
This release accidentally got the same `bottle :unneeded` line, which
breaks homebrew, so I'm removing it.